### PR TITLE
remove empty annotation and review datagrid

### DIFF
--- a/annotation-app/src/app/components/admin/admin.component.html
+++ b/annotation-app/src/app/components/admin/admin.component.html
@@ -46,7 +46,7 @@ SPDX-License-Identifier: Apache-2.0 -->
             >Project Name
           </clr-dg-column>
           <clr-dg-column
-            [clrDgField]="'projectName'"
+            [clrDgField]="'projectType'"
             class="ellipsis-datagrid"
             style="max-width: 200px"
             >Project Type
@@ -57,7 +57,7 @@ SPDX-License-Identifier: Apache-2.0 -->
           <clr-dg-column [clrDgField]="'updatedDate'" class="ellipsis-datagrid"
             >Updated Date</clr-dg-column
           >
-          <!-- <clr-dg-column [clrDgField]="'updatedDate'" class="ellipsis-datagrid">Generate Updated Date</clr-dg-column> -->
+
           <clr-dg-column
             [clrDgField]="'dataSource'"
             class="ellipsis-datagrid"

--- a/annotation-app/src/app/components/admin/admin.component.scss
+++ b/annotation-app/src/app/components/admin/admin.component.scss
@@ -84,7 +84,7 @@ clr-control-helper {
   -webkit-box-orient: vertical;
   overflow: hidden;
   height: 4rem;
-  line-height: 0.7rem;
+  line-height: 0.9rem;
 }
 
 .showIcon {

--- a/annotation-app/src/app/components/game-form/game-form.component.scss
+++ b/annotation-app/src/app/components/game-form/game-form.component.scss
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
   -webkit-box-orient: vertical;
   overflow: hidden;
   height: 4.1rem;
-  line-height: 0.7rem;
+  line-height: 0.9rem;
 }
 
 .isShowHide {

--- a/annotation-app/src/app/components/projects/annotate/annotate.component.html
+++ b/annotation-app/src/app/components/projects/annotate/annotate.component.html
@@ -720,7 +720,7 @@ SPDX-License-Identifier: Apache-2.0 -->
             </div>
           </div>
           <div
-            *ngIf="(projectType == 'text' || projectType == 'tabular') && startFrom === 'review'"
+            *ngIf="(projectType == 'text' || projectType == 'tabular') && startFrom === 'review' && moreReviewInfo.length>0"
             class="limit-height"
           >
             <h5 style="margin-top: 1rem">Annotator labeled results:</h5>

--- a/annotation-app/src/app/components/projects/annotate/annotate.component.ts
+++ b/annotation-app/src/app/components/projects/annotate/annotate.component.ts
@@ -1519,7 +1519,7 @@ export class AnnotateComponent implements OnInit, AfterViewInit, OnDestroy {
           this.submitMessage = 'submit';
           this.fetchData();
         }
-        this.tipMessage = `The current label is diiferent from the original existing label, please do ${this.submitMessage} first.`;
+        this.tipMessage = `The current label is different from the original existing label, please do ${this.submitMessage} first.`;
       },
       (error) => {
         console.log(error);

--- a/annotation-app/src/app/components/projects/preview/preview-projects.component.html
+++ b/annotation-app/src/app/components/projects/preview/preview-projects.component.html
@@ -192,9 +192,6 @@ SPDX-License-Identifier: Apache-2.0 -->
                 <clr-dg-column class="ellipsis-datagrid" style="min-width: 250px"
                   >Annotator
                 </clr-dg-column>
-                <!-- <clr-dg-column class="ellipsis-datagrid"
-                  >Reviewed Info
-                </clr-dg-column> -->
                 <clr-dg-column class="ellipsis-datagrid" style="min-width: 250px"
                   >Action
                 </clr-dg-column>
@@ -324,13 +321,6 @@ SPDX-License-Identifier: Apache-2.0 -->
                     >
                       <div *ngFor="let a of dataset.userInputs">{{ a.user }}</div>
                     </clr-dg-cell>
-                    <!-- <clr-dg-cell
-                      class="ellipsis-datagrid previewHeight"
-                    >
-                      <div>{{ dataset.reviewInfo.reviewedTime? (dataset.reviewInfo.reviewedTime | date: 'yyyy-MM-dd HH:mm:ss'):'None'}}
-                        <span *ngIf="dataset.reviewInfo.reviewedTime" class="reviewType">{{dataset.reviewInfo.modified?'Modified':'Passed'}}</span>
-                      </div>
-                    </clr-dg-cell> -->
                     <clr-dg-cell class="ellipsis-datagrid previewHeight" style="min-width: 250px">
                       <div class="clr-row">
                         <button
@@ -347,7 +337,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                       *ngIf="dataset.userInputsLength > 0 || dataset?.originalInputs > 0"
                     >
                       <clr-dg-row-detail class="annotateDetail{{ i }}" (clrIfExpanded)="(true)">
-                          <clr-datagrid>
+                          <clr-datagrid *ngIf="dataset.userInputs.length>0">
                           <clr-dg-column>
                             Annotator                          
                           </clr-dg-column>
@@ -467,8 +457,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                       </clr-dg-row-detail>
                       <clr-dg-row-detail class="reviewDetail{{ i }}" (clrIfExpanded)="(true)" style="margin-bottom: 1rem;">
                       <!-- review data datagrid -->
-                      <clr-datagrid>
-                        <clr-dg-placeholder>No review data yet!</clr-dg-placeholder>
+                      <clr-datagrid *ngIf="dataset.reviewInfo.userInputs.length>0">
                         <clr-dg-column>
                           Reviewer                          
                         </clr-dg-column>
@@ -553,7 +542,7 @@ SPDX-License-Identifier: Apache-2.0 -->
                             </ul>
                           </clr-dg-cell>
                           <clr-dg-cell *ngIf="projectType == 'ner'" class="studioCell">
-                            <clr-datagrid>
+                            <clr-datagrid *ngIf="flag.problemCategory">
                               <clr-dg-column *ngFor="let title of innerTable">
                                 {{ title }}
                               </clr-dg-column>

--- a/annotation-app/src/app/components/projects/projects.component.scss
+++ b/annotation-app/src/app/components/projects/projects.component.scss
@@ -78,7 +78,7 @@ ul li {
   -webkit-box-orient: vertical;
   overflow: hidden;
   height: 4.1rem;
-  line-height: 0.7rem;
+  line-height: 0.9rem;
 }
 
 .showIcon {


### PR DESCRIPTION
- remove empty datagrid in latest annotation data preview tab
- hide the inner datagrid if the review action is pass when project type is ner
- correct the word spelling to 'different' in err alert
- correct the filter bind property of project type in admin datagrid
- fix the annotator email hidden issue in datagrid when the assigned annotators list is long 